### PR TITLE
fix: change `call` payload as bytes

### DIFF
--- a/kwil/tx/v1/call.proto
+++ b/kwil/tx/v1/call.proto
@@ -4,25 +4,12 @@ option go_package = "github.com/kwilteam/kwil-db/api/protobuf/tx/v1;txpb";
 
 import "kwil/tx/v1/tx.proto";
 
-message CallPayload {
-  string dbid = 1;
-  string action = 2;
-  map<string, ScalarValue> args = 3;
-}
-
 message CallRequest {
-  CallPayload payload = 1;
+  bytes payload = 1;
   tx.Signature signature = 2;
   string sender = 3;
 }
 
 message CallResponse {
   bytes result = 1;
-}
-
-message ScalarValue {
-  oneof value {
-    string string_value = 1;
-    int64 int_value = 2;
-  }
 }


### PR DESCRIPTION
as the result serialization of Json object is language specific, client and server could not agree on the data to hash/sign