### PR TITLE
fix: make multi letter fields using snake case in json

### DIFF
--- a/kwil/tx/v1/broadcast.proto
+++ b/kwil/tx/v1/broadcast.proto
@@ -9,5 +9,5 @@ message BroadcastRequest {
 }
 
 message BroadcastResponse {
-    bytes tx_hash = 1;
+    bytes tx_hash = 1 [json_name = "tx_hash"];
 }

--- a/kwil/tx/v1/tx.proto
+++ b/kwil/tx/v1/tx.proto
@@ -5,7 +5,7 @@ option go_package = "github.com/kwilteam/kwil-db/api/protobuf/tx/v1;txpb";
 message Transaction {
     message Body {
         bytes payload = 1;
-        string payload_type = 2;
+        string payload_type = 2 [json_name = "payload_type"];
         string fee = 3;
         uint64 nonce = 4;
         bytes salt = 5;
@@ -23,8 +23,8 @@ message Signature {
 message TransactionResult {
   uint32 code = 1;
   string log = 2;
-  int64 gas_used = 3;
-  int64 gas_wanted = 4;
+  int64 gas_used = 3 [json_name = "gas_used"];
+  int64 gas_wanted = 4 [json_name = "gas_wanted"];
   bytes data = 5; // Data contains the output of the transaction.
   repeated bytes events = 6;
 }

--- a/kwil/tx/v1/tx_query.proto
+++ b/kwil/tx/v1/tx_query.proto
@@ -5,12 +5,12 @@ option go_package = "github.com/kwilteam/kwil-db/api/protobuf/tx/v1;txpb";
 import "kwil/tx/v1/tx.proto";
 
 message TxQueryRequest {
-  bytes tx_hash = 1;
+  bytes tx_hash = 1 [json_name = "tx_hash"];
 }
 
 message TxQueryResponse {
   bytes hash = 1;
   uint64 height = 2;
   tx.Transaction tx = 3;
-  tx.TransactionResult tx_result = 4;
+  tx.TransactionResult tx_result = 4 [json_name = "tx_result"];
 }

--- a/kwil/tx/v1/validator.proto
+++ b/kwil/tx/v1/validator.proto
@@ -34,7 +34,7 @@ message ValidatorJoinRequest {
     tx.Transaction tx = 1;
 }
 
-message ValidatorJoinResponse { 
+message ValidatorJoinResponse {
     tx.TransactionStatus receipt = 1;
 }
 
@@ -63,7 +63,7 @@ message ValidatorJoinStatusResponse {
     int64 approved = 1;
     int64 rejected = 2;
     int64 pending = 3;
-    repeated string approvedValidators = 4;
-    repeated string rejectedValidators = 5;
+    repeated string approved_validators = 4 [json_name = "approved_validators"];
+    repeated string rejected_validators = 5 [json_name = "rejected_validators"];
     JoinStatus status = 6;
 }


### PR DESCRIPTION
kwilteam/kwil-db#238

those fields are tagged in proto definition to use snake case(in grpc-gateway):
- tx_hash
- gas_used
- gas_wanted
- tx_result
- approved_validators
- rejected_validators