### PR TITLE
fix: tx query height integer overflow

### DIFF
--- a/kwil/tx/v1/tx_query.proto
+++ b/kwil/tx/v1/tx_query.proto
@@ -10,7 +10,7 @@ message TxQueryRequest {
 
 message TxQueryResponse {
   bytes hash = 1;
-  uint64 height = 2;
+  int64 height = 2;
   tx.Transaction tx = 3;
   tx.TransactionResult tx_result = 4 [json_name = "tx_result"];
 }


### PR DESCRIPTION
`TxQueryResponse` returned a uint64 for height.  CometBFT returns -1 if a tx is in the mempool.  I switched height to int64 to support this.