### PR TITLE
feat: call rpc support friendly signature

### DIFF
--- a/kwil/tx/v1/call.proto
+++ b/kwil/tx/v1/call.proto
@@ -5,10 +5,15 @@ option go_package = "github.com/kwilteam/kwil-db/api/protobuf/tx/v1;txpb";
 import "kwil/tx/v1/tx.proto";
 
 message CallRequest {
-  bytes payload = 1;
+  message Body{
+    string description = 1;
+    bytes payload = 2;
+  }
+
+  Body body = 1;
   tx.Signature signature = 2;
   bytes sender = 3;
-}
+  string serialization = 4;}
 
 message CallResponse {
   bytes result = 1;


### PR DESCRIPTION
According to kwilteam/kwil-db#278, this pr change `call` rpc to support friendly signature.

The intention is to make the request similar to `BroadcastRequest`