### PR TITLE
added rpc to get the nodes broadcast address in the admin svc

### DIFF
--- a/kwil/admin/v0/messages.proto
+++ b/kwil/admin/v0/messages.proto
@@ -62,3 +62,8 @@ message PeersRequest {}
 message PeersResponse {
 	repeated Peer peers = 1;
 }
+
+message BroadcastAddressRequest {}
+message BroadcastAddressResponse {
+	string broadcast_address = 1;
+}

--- a/kwil/admin/v0/service.proto
+++ b/kwil/admin/v0/service.proto
@@ -30,4 +30,10 @@ service AdminService {
             get: "/api/v0/peers"
         };
     }
+
+    rpc BroadcastAddress(BroadcastAddressRequest) returns (BroadcastAddressResponse) {
+        option (google.api.http) = {
+            get: "/api/v0/broadcast_address"
+        };
+    }
 }


### PR DESCRIPTION
Right now, we have this really weird piece of UX where a user of the admin endpoint also needs to use the regular tx service for broadcasting validator votes.  This allows us to circumvent this by adding an rpc in the admin service that returns the node's configured broadcast address.