### PR TITLE
removed ping from the admin service

### DIFF
--- a/kwil/admin/v0/messages.proto
+++ b/kwil/admin/v0/messages.proto
@@ -2,14 +2,6 @@ syntax = "proto3";
 package admin;
 option go_package = "github.com/kwilteam/kwil-db/core/rpc/protobuf/admin/v0;admpb";
 
-message PingRequest {
-  string message = 1;
-}
-
-message PingResponse {
-  string message = 1;
-}
-
 message VersionRequest {}
 message VersionResponse {
 	string version_string = 1;

--- a/kwil/admin/v0/service.proto
+++ b/kwil/admin/v0/service.proto
@@ -7,12 +7,6 @@ import "kwil/admin/v0/messages.proto";
 import "google/api/annotations.proto";
 
 service AdminService {
-    rpc Ping(PingRequest) returns (PingResponse) {
-        option (google.api.http) = {
-            get: "/api/v0/ping"
-        };
-    }
-
     rpc Version(VersionRequest) returns (VersionResponse) {
         option (google.api.http) = {
             get: "/api/v0/version"


### PR DESCRIPTION
Since we are now including tx functionality in the admin service, we now have an issue where it double registers the `ping` rpc.  I have removed it from the admin service.